### PR TITLE
Add profile modal for graph nodes

### DIFF
--- a/src/components/ProfileModal.tsx
+++ b/src/components/ProfileModal.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import * as React from "react";
+
+interface Profile {
+  id: string;
+  firstName: string;
+  lastName: string;
+  linkedinUrl: string;
+}
+
+interface ProfileModalProps {
+  profile: Profile | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ProfileModal({
+  profile,
+  open,
+  onOpenChange,
+}: ProfileModalProps) {
+  if (!profile) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md w-full">
+        <DialogHeader>
+          <DialogTitle>Profile</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-lg font-semibold">
+              {profile.firstName} {profile.lastName}
+            </h3>
+          </div>
+          <div>
+            <a
+              href={profile.linkedinUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              View LinkedIn Profile
+            </a>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
# Add Profile Modal for Graph Nodes

This PR implements the feature requested in #3 to show a profile modal when clicking on a node in the social graph.

## Changes

- Created a new `ProfileModal` component that displays:
  - User's full name
  - Link to their LinkedIn profile
- Modified `SocialGraph` component to:
  - Handle node clicks
  - Show the profile modal with the selected user's information
  - Convert API profile data to the format expected by the modal

## Testing

1. Click on any node in the graph
2. A modal should appear showing the user's name and a link to their LinkedIn profile
3. Clicking outside the modal or the close button should dismiss it
4. The modal should work in both light and dark modes

## Screenshots

[Add screenshots here after testing]
