### PR TITLE
fix: ensure connection idempotency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ next-env.d.ts
 
 /src/generated/prisma
 .env*.local
+pr_body.md

--- a/src/app/api/add/helpers.ts
+++ b/src/app/api/add/helpers.ts
@@ -13,9 +13,11 @@ export async function upsertProfile(
 }
 
 export async function upsertConnection(profile_a: string, profile_b: string) {
+  // Ensure idempotency by lexicographically ordering profile_a and profile_b
+  const [a, b] = [profile_a, profile_b].sort();
   return prisma.connections.upsert({
-    where: { profile_a_profile_b: { profile_a, profile_b } },
+    where: { profile_a_profile_b: { profile_a: a, profile_b: b } },
     update: {},
-    create: { profile_a, profile_b },
+    create: { profile_a: a, profile_b: b },
   });
 }

--- a/tests/api/add/route.test.ts
+++ b/tests/api/add/route.test.ts
@@ -41,4 +41,14 @@ describe("upsertConnection", () => {
       create: { profile_a: "a", profile_b: "b" },
     });
   });
+
+  it("ensures idempotency by lexicographically ordering profile_a and profile_b", async () => {
+    mockConnectionsUpsert.mockResolvedValueOnce({});
+    await upsertConnection("b", "a");
+    expect(mockConnectionsUpsert).toHaveBeenCalledWith({
+      where: { profile_a_profile_b: { profile_a: "a", profile_b: "b" } },
+      update: {},
+      create: { profile_a: "a", profile_b: "b" },
+    });
+  });
 });


### PR DESCRIPTION
# Connection Idempotency Fix

## Changes

- Modified `upsertConnection` helper function to ensure idempotency by lexicographically ordering `profile_a` and `profile_b` values
- Added test to validate idempotency behavior

## Why

This change ensures that connections are stored consistently regardless of the order in which they are created. For example, a connection between profiles "A" and "B" will always be stored with "A" as `profile_a` and "B" as `profile_b`, preventing duplicate entries in the database.

## Testing

- Added new test case to verify idempotency behavior
- All existing tests pass
- No linting issues
- Build successful
